### PR TITLE
Add base implementation of snap points for scroll view

### DIFF
--- a/Example/screens/DelegateScroll/DelegateScroll.js
+++ b/Example/screens/DelegateScroll/DelegateScroll.js
@@ -8,12 +8,19 @@ import {
   delegate,
 } from './components/Header/constants';
 
+const snapPoints = [
+  { from: 0, to: 28, snap: 0 },
+  { from: 28, to: 51, snap: 51 },
+];
+
 const App = () => (
   <View style={s.container}>
     <ScrollView
       contentContainerStyle={{
         paddingTop: MAX_HEADER_HEIGHT,
       }}
+      initialScrollPosition={{ y: 51 }}
+      snapPoints={snapPoints}
       scrollEventThrottle={1}
       delegate={delegate}
     >

--- a/lib/components/ScrollView.js
+++ b/lib/components/ScrollView.js
@@ -3,25 +3,94 @@ import T from 'prop-types';
 import A from 'react-native-reanimated';
 
 class ScrollView extends React.PureComponent {
+  componentDidMount() {
+    if (this.props.initialScrollPosition) {
+      this.scrollTo({
+        ...this.props.initialScrollPosition,
+        animated: false,
+      });
+    }
+  }
+
   componentWillUnmount() {
     this.props.delegate.reset();
   }
 
+  _ref = React.createRef();
+  scrollPosition = 0;
+
+  scrollTo(value) {
+    global.requestAnimationFrame(() =>
+      this._ref.current._component.scrollTo(value),
+    );
+  }
+
+  _onScroll(value) {
+    if (this.props.onScroll) {
+      this.props.onScroll(value);
+    }
+
+    this.scrollPosition = value;
+  }
+
+  _onScrollEndDrag(evt) {
+    this.props.snapPoints.forEach((item) => {
+      const { from, to, snap } = item;
+
+      if (this.scrollPosition > from && this.scrollPosition <= to) {
+        this.scrollTo(
+          this.props.vertical ? { x: snap } : { y: snap },
+        );
+      }
+    });
+
+    if (this.props.onScrollEndDrag) {
+      this.props.onScrollEndDrag(evt);
+    }
+  }
+
   render() {
+    const { delegate } = this.props;
+
+    const props = {
+      ...this.props,
+      onScroll: delegate.event,
+      onScrollEndDrag: (evt) => this._onScrollEndDrag(evt),
+    };
+
     return (
-      <A.ScrollView
-        {...this.props}
-        onScroll={this.props.delegate.event}
-      />
+      <React.Fragment>
+        <A.Code
+          exec={A.block([
+            A.call([delegate.value], (r) => this._onScroll(r[0])),
+            delegate.value,
+          ])}
+        />
+        <A.ScrollView ref={this._ref} {...props} />
+      </React.Fragment>
     );
   }
 }
 
 ScrollView.propTypes = {
   delegate: T.shape({
-    event: T.object,
+    event: T.func,
     reset: T.func,
   }),
+  onScroll: T.func,
+  onScrollEndDrag: T.func,
+  vertical: T.bool,
+  initialScrollPosition: T.shape({
+    x: T.number,
+    y: T.number,
+  }),
+  snapPoints: T.arrayOf(
+    T.shape({
+      from: T.number,
+      to: T.number,
+      snap: T.number,
+    }),
+  ),
 };
 
 export default ScrollView;

--- a/lib/core/createDelegate.js
+++ b/lib/core/createDelegate.js
@@ -3,19 +3,29 @@ import * as objectPath from '../utils/objectPath';
 
 export default function createDelegate(eventType, path) {
   const value = new Animated.Value(0);
+
   const eventMap = objectPath.map(
     ['nativeEvent'].concat(path),
     value,
   );
+
   const event = Animated.event([eventMap]);
 
   function reset() {
     value.setValue(0);
   }
 
+  function attachListener(listener) {
+    Animated.block([
+      Animated.call([value], (r) => listener(r[0])),
+      value,
+    ]);
+  }
+
   return {
     event,
     value,
+    attachListener,
     reset,
   };
 }

--- a/lib/core/createDelegate.js
+++ b/lib/core/createDelegate.js
@@ -15,17 +15,9 @@ export default function createDelegate(eventType, path) {
     value.setValue(0);
   }
 
-  function attachListener(listener) {
-    Animated.block([
-      Animated.call([value], (r) => listener(r[0])),
-      value,
-    ]);
-  }
-
   return {
     event,
     value,
-    attachListener,
     reset,
   };
 }


### PR DESCRIPTION
This PR adds snap points, initial scroll position prop and some ref methods to ScrollView delegate animation.
Also, adding a missing onScroll event listener (via a little hack with Animated.Code block).